### PR TITLE
Updated current school file

### DIFF
--- a/SPEDcurrentSelection.sql
+++ b/SPEDcurrentSelection.sql
@@ -195,8 +195,8 @@ ORDER BY
 <th>Incident Date</th>
 <th>Incident ID</th>
 <th>Incident Title</th>
-<th>Incident Category</th>
 <th>Incident Role</th>
+<th>Incident Category</th>
 <th>Action Resolved</th>
 <th>Action Code</th>
 <th>Action Plan Begin Date</th>

--- a/SPEDdistrict.sql
+++ b/SPEDdistrict.sql
@@ -158,7 +158,6 @@ RankedResults AS (
 SELECT
     student_link,
     state_id,
-    -- student_lastfirst,
     sped_code,
     english_learner_code,
     incident_ts,
@@ -193,10 +192,10 @@ ORDER BY
 <th>Incident Date</th>
 <th>Incident ID</th>
 <th>Incident Title</th>
-<th>Incident Category</th>
 <th>Incident Role</th>
-<th>Action Code</th>
+<th>Incident Category</th>
 <th>Action Resolved</th>
+<th>Action Code</th>
 <th>Action Plan Begin Date</th>
 <th>Action Plan End Date</th>
 <th>Duration Assigned</th>


### PR DESCRIPTION
This pull request introduces significant changes to the SQL queries used for generating SPED (Special Education) reports. The updates focus on restructuring the queries for better modularity, adding new data points, and improving the organization of the output. Below is a summary of the key changes:

### Major Query Restructuring and Modularization:
* Refactored the `SPEDcurrentSchool.sql` file to include new Common Table Expressions (CTEs) such as `yearquery`, `sped_cte`, `el_cte`, `role_cte`, and others for better modularity and maintainability. These CTEs separate logic for SPED, English Learner (EL) codes, roles, and actions.
* Replaced the previous `RankedData` CTE with a new `RankedResults` CTE that integrates these modular CTEs and adds additional fields like `school_abbreviation`, `sped_code`, and `english_learner_code`.

### Enhancements to Output Data:
* Added new fields to the output, including `state_id`, `sped_code`, `english_learner_code`, `action_short_desc`, and `school_abbreviation`. These provide more detailed information about students and incidents.
* Updated the `<th>` headers in the output to reflect the new fields, ensuring the report format matches the new data structure.

### Reorganization of Columns in Output:
* Adjusted the order of columns in the `ORDER BY` clause for better logical grouping and readability in `SPEDcurrentSelection.sql` and `SPEDdistrict.sql`. For example, moved `Incident Category` to follow `Incident Role`. [[1]](diffhunk://#diff-368bdb2f4011a8509b2310b56b7ba23c0827645f0b90f18ee984c5c15c64725eL198-R199) [[2]](diffhunk://#diff-b643dae75be66cbb3cc9a6f04620a3897091f9fba4cb442cee5b1e42a871fbeaL196-R198)

### Minor Cleanups:
* Removed commented-out code and unused fields, such as `student_lastfirst`, from the `RankedResults` query in `SPEDdistrict.sql`.

These changes improve the clarity, maintainability, and functionality of the SPED reporting queries.